### PR TITLE
USAGOV-1052: Explicitly override DOCKER_CONTENT_TRUST flag for the luacheck container

### DIFF
--- a/bin/scan-lua.sh
+++ b/bin/scan-lua.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 # luacheck image tags include "latest" and "edge," "edge" being later than "latest"
-docker run -it --rm \
+# Explicitly turn off DOCKER_CONTENT_TRUST, as pipelinecomponents are not signing their images.
+# (Okay because we are not using this to build an image).
+docker run --disable-content-trust -it --rm \
       -v "$(pwd)/project_conf:/code/project_conf" \
       pipelinecomponents/luacheck:latest luacheck project_conf/scripts


### PR DESCRIPTION
Adds `--disable-content-trust` to the `docker run` command for luacheck. 

This seems kind of silly, because the only reason I need this is that I added DOCKER_CONTENT_TRUST=1 to our CircleCI environment variables. And since this is the only docker image being used in this project, one could reasonably ask "why?". My answer is that I think we should enable DOCKER_CONTENT_TRUST by default and be explicit about where we're overriding it. 

An alternative would be to specify the image by digest, but: 
1) Then I would have to check the architecture, as "latest" retrieves a different image based on amd64/arm64
2) I do want "latest" for code scans and linting