### PR TITLE
USAGOV-1381: configure repo

### DIFF
--- a/.git.commit-msg
+++ b/.git.commit-msg
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+COMMIT_MESSAGE_FILE="$1"
+COMMIT_MESSAGE=$(cat "$COMMIT_MESSAGE_FILE" | grep -v '^#')
+
+COMMITPREFIX=$(git branch | grep '*' | sed 's/* //') 
+
+if [ ${#COMMIT_MESSAGE} = 0 ]
+then
+    exit 1
+fi
+echo "$COMMITPREFIX"': '"$COMMIT_MESSAGE" > "$COMMIT_MESSAGE_FILE"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+<!--- Provide a general summary of your changes in the title above -->
+## Jira Task
+<!--- Provide a link to the Jira ticket -->
+https://cm-jira.usa.gov/browse/USAGOV-
+
+## Description
+<!--- Summarize the changes made in this pull request, not what it's for. -->
+
+## Type of Changes
+<!--- Put an `x` in all the boxes that apply. -->
+- [ ] New Feature
+- [ ] Bugfix
+- [ ] Other
+
+## Testing Instructions
+<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
+<!-- Not “see Jira” – if they are really the same, copy and paste. -->
+
+
+
+## Security Review
+<!-- Checkboxes to indicate need for review -->
+
+- [ ] Adds/updates software (including a library or Drupal module)
+- [ ] Communication with external service
+- [ ] Changes permissions or workflow
+- [ ] Requires SSPP updates
+
+
+## Reviewer Reminders
+- Reviewed code changes
+- Reviewed functionality
+- Security review complete or not required
+
+## Post PR Approval Instructions
+Follow these steps as soon as you merge the new changes. 
+
+1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-logshipper).
+2. Find the commit of this pull request.
+3. Deploy the log-shipper. Watch the logs and make sure all went well.
+4. Update the Jira ticket by changing the ticket status to `Done` and add a comment. 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,20 @@
 
 This repo contains USAGov-specific configuration for the https://github.com/gsa-tts/cg-logshipper.
 
+## Developer setup
+
+You will need the Cloud Foundry command line and a place to deploy the log-shipper in order to test your work. This project uses buildpacks and is not set up to run locally (e.g., in Docker). 
+
+Contributors on the USAGov team should run `bin/init` after cloning this repo. Currently, this simply installs a commit-msg hook. Then when starting a new feature, create a branch named for the Jira ticket of a new feature:
+
+```
+git checkout -b USAGOV-###-new-feature-branch
+```
+
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for additional information.
+
 
 ## Public domain
 

--- a/bin/init
+++ b/bin/init
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Following the convention used in usagov-2021, this script is to be run
+# after cloning this repo.
+
+echo "Set up git hooks"
+if [ ! -f .git/hooks/commit-msg ]; then
+  cp .git.commit-msg .git/hooks/commit-msg
+  chmod +x .git/hooks/commit-msg
+fi


### PR DESCRIPTION
Adds a PR template and a commit message hook (with bin/init script to install it) similar to what we have in the usagov-2021 repo. (I guess the PR template will take effect after this is merged ... or I've missed something.) 

Testing recommendation: clone this repo, switch to this branch, and run bin/init as described in the README. Then confirm that the commit hook code has been copied to .git/hooks/commit-msg . 