### PR TITLE
USAGOV-1698: specify a random route and not hard-code 'tools' as the space for the log drain.

### DIFF
--- a/bin/add-log-drains-for-space.sh
+++ b/bin/add-log-drains-for-space.sh
@@ -4,11 +4,13 @@
 
 set -o pipefail
 
+SPACE=${SPACE:-tools}
+
 SERVICE_EXISTS=`cf service log-shipper-drain --guid`
 
 if [ "$SERVICE_EXISTS" = "FAILED" ]; then
     echo "Creating log-shipper-drain service"
-    cf create-user-provided-service log-shipper-drain -l "https://${HTTP_USER}:${HTTP_PASS}@usagov-tools-logshipper.app.cloud.gov/?drain-type=all"
+    cf create-user-provided-service log-shipper-drain -l "https://${HTTP_USER}:${HTTP_PASS}@usagov-${SPACE}-logshipper.app.cloud.gov/?drain-type=all"
 else
     echo "Service log-shipper-drain already exists."
 fi

--- a/bin/deploy-logshipper.sh
+++ b/bin/deploy-logshipper.sh
@@ -34,4 +34,4 @@ echo "    cg-logshipper commit:" $(git log -1 --pretty=format:"%H") >> ./DEPLOYE
 echo "    containertag:" $CONTAINERTAG >> ./DEPLOYED_VERSION.txt
 
 # And push the app from the cg-logshipper directory
-cf push log-shipper --instances 2 --strategy rolling
+cf push log-shipper --instances 2 --random-route --strategy rolling


### PR DESCRIPTION

This enables us to stand up another log-shipper in a DR space for testing, while leaving the default for regular deployment to tools

<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1698

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->



## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes. 

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-logshipper).
2. Find the commit of this pull request.
3. Deploy the log-shipper. Watch the logs and make sure all went well.
4. Update the Jira ticket by changing the ticket status to `Done` and add a comment. 
