### PR TITLE
USAGOV-1970: Increase allowed size of POST body in nginx

### DIFF
--- a/bin/deploy-logshipper.sh
+++ b/bin/deploy-logshipper.sh
@@ -25,6 +25,12 @@ cp -rp project_conf cg-logshipper
 
 cd cg-logshipper
 
+# Increase the acceptable body size for POST bodies; 8K was too small.
+sed -i.bak \
+    -e "s|client_body_buffer_size 8K;|client_body_buffer_size 16K;|" \
+    -e "s|client_max_body_size 8K;|client_max_body_size 16K;|" \
+    ./nginx.conf
+
 # Write a status file we can inspect if needed:
 echo "USAGov log-shipper deployment version:" >> ./DEPLOYED_VERSION.txt
 echo "    built:" $(date) >> ./DEPLOYED_VERSION.txt


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1970

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
Increase the `client_body_buffer_size` and `client_max_body_size` values in nginx.conf to 16K. 

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->
```
% cf target -s dr
% bin/deploy-logshipper.sh
```
 - Examine cg-logshipper/nginx.conf; the sizes of client_body_buffer_size and client_max_body_size should be 16K. There will also be an nginx.conf.bak file, showing the original 8K. 
 - Watch the log-shipper logs to see that deployment went smoothly. 


## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes. 

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-logshipper).
2. Find the commit of this pull request.
3. Deploy the log-shipper. Watch the logs and make sure all went well.
4. Update the Jira ticket by changing the ticket status to `Done` and add a comment. 
