### PR TITLE
USAGOV-1488: Scale up memory and number of instances

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,13 +120,11 @@ workflows:
             branches:
               only:
                 - main
-                - USAGOV-1488-scale-up
       - deploy-app-to-cloudgov-tools:
           filters:
             branches:
               only:
                 - main
-                - USAGOV-1488-scale-up
           requires:
             - approve-deploy
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,11 +120,13 @@ workflows:
             branches:
               only:
                 - main
+                - USAGOV-1488-scale-up
       - deploy-app-to-cloudgov-tools:
           filters:
             branches:
               only:
                 - main
+                - USAGOV-1488-scale-up
           requires:
             - approve-deploy
 

--- a/bin/deploy-logshipper.sh
+++ b/bin/deploy-logshipper.sh
@@ -40,4 +40,4 @@ echo "    cg-logshipper commit:" $(git log -1 --pretty=format:"%H") >> ./DEPLOYE
 echo "    containertag:" $CONTAINERTAG >> ./DEPLOYED_VERSION.txt
 
 # And push the app from the cg-logshipper directory
-cf push log-shipper --instances 4 --memory 256M --random-route --strategy rolling
+cf push log-shipper --instances 3 --memory 256M --random-route --strategy rolling

--- a/bin/deploy-logshipper.sh
+++ b/bin/deploy-logshipper.sh
@@ -40,4 +40,4 @@ echo "    cg-logshipper commit:" $(git log -1 --pretty=format:"%H") >> ./DEPLOYE
 echo "    containertag:" $CONTAINERTAG >> ./DEPLOYED_VERSION.txt
 
 # And push the app from the cg-logshipper directory
-cf push log-shipper --instances 3 --memory 256M --random-route --strategy rolling
+cf push log-shipper --instances 4 --memory 256M --random-route --strategy rolling

--- a/bin/deploy-logshipper.sh
+++ b/bin/deploy-logshipper.sh
@@ -40,4 +40,4 @@ echo "    cg-logshipper commit:" $(git log -1 --pretty=format:"%H") >> ./DEPLOYE
 echo "    containertag:" $CONTAINERTAG >> ./DEPLOYED_VERSION.txt
 
 # And push the app from the cg-logshipper directory
-cf push log-shipper --instances 2 --random-route --strategy rolling
+cf push log-shipper --instances 3 --memory 350M --random-route --strategy rolling

--- a/bin/deploy-logshipper.sh
+++ b/bin/deploy-logshipper.sh
@@ -40,4 +40,4 @@ echo "    cg-logshipper commit:" $(git log -1 --pretty=format:"%H") >> ./DEPLOYE
 echo "    containertag:" $CONTAINERTAG >> ./DEPLOYED_VERSION.txt
 
 # And push the app from the cg-logshipper directory
-cf push log-shipper --instances 3 --memory 350M --random-route --strategy rolling
+cf push log-shipper --instances 3 --memory 256M --random-route --strategy rolling


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1488

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
Increases number of instances to 3. 

Also explicitly specifies 256MB memory. That's because I wanted to change that as well, but our current memory quota won't quite let me (although I could scale to that). I decided to leave the `--memory 256M` in there because it will be handy to just update that later and it's nice to be explicit. 

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [x] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->
N/A


## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes. 

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-logshipper).
2. Find the commit of this pull request.
3. Deploy the log-shipper. Watch the logs and make sure all went well.
4. Update the Jira ticket by changing the ticket status to `Done` and add a comment. 
