### PR TITLE
USAGOV-2236: Supply --no-route arg only when app does not already exist

### DIFF
--- a/bin/deploy-logshipper.sh
+++ b/bin/deploy-logshipper.sh
@@ -3,6 +3,17 @@
 NUM_INSTANCES=${1:-"1"}
 CONTAINERTAG=${2:-"/no pipeline number/"}
 
+function appExists {  # appname
+  app=$1
+  if [ -z "$app" ]; then
+    echo "ERROR: appname is required"
+    exit 1
+  fi
+  cf app $app > /dev/null 2>&1
+  return $?
+}
+
+
 
 # Get our branch and commit has for the status file:
 USAGOV_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
@@ -38,5 +49,10 @@ echo "    usagov-logshipper commit:" $USAGOV_COMMIT >> ./DEPLOYED_VERSION.txt
 echo "    cg-logshipper commit:" $(git log -1 --pretty=format:"%H") >> ./DEPLOYED_VERSION.txt
 echo "    containertag:" $CONTAINERTAG >> ./DEPLOYED_VERSION.txt
 
+NO_ROUTE="--no-route"
+if appExists log-shipper; then
+    NO_ROUTE=""
+fi
+
 # Push the app from the cg-logshipper directory
-cf push log-shipper --instances ${NUM_INSTANCES} --memory 256M --no-route --strategy rolling
+cf push log-shipper --instances ${NUM_INSTANCES} ${NO_ROUTE} --memory 256M --strategy rolling


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2236

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
TIL that if you `cf push` an app that already exists and supply the `--no-route` argument, the existing mapped route will be unmapped. We want to supply `--no-route` when we first push the app so we can create and map our own space-specific route, but after that, we want to leave the existing route in place. 

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->
:shrug:


## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes. 

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-logshipper).
2. Find the commit of this pull request.
3. Deploy the log-shipper. Watch the logs and make sure all went well.
4. Update the Jira ticket by changing the ticket status to `Done` and add a comment. 
